### PR TITLE
Enable coordinate automation and Excel bridge

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -86,15 +86,22 @@ def process_excel_file(file_path: Path | str) -> List[Dict[str, object]]:
     return results
 
 
-def process_excel_to_coordinates() -> List[Dict[str, str]]:
-    """Return records formatted for coordinate-based automation."""
+def convert_to_coordinate_format(excel_data: List[Dict[str, object]]) -> List[Dict[str, str]]:
+    """Convert processed Excel data to coordinate automation format."""
     return [
         {
-            "hesap_no": "6293986",
-            "tarih": "25.07.2025",
-            "banka_kodu": "062",
-            "cari_kodu": "120.12.001",
-            "tutar": "1250.75",
-            "aciklama": "POS Tahsilatı",
+            "hesap_no": item["hesap_no"],
+            "tarih": item["tarih"],
+            "banka_kodu": "062",  # Default bank code
+            "cari_kodu": "120.12.001",  # Default client code
+            "tutar": str(item["toplam_tutar"]),
+            "aciklama": item["aciklama"],
         }
+        for item in excel_data
     ]
+
+
+def process_excel_to_coordinates(file_path: Path | str) -> List[Dict[str, str]]:
+    """Load Excel and return records formatted for coordinate-based automation."""
+    excel_data = process_excel_file(file_path)
+    return convert_to_coordinate_format(excel_data)

--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -25,6 +25,13 @@ class PrestonRPAV2:
             "havale_alma": (848, 566),
             "banka_field": (848, 629),
             "cari_field": (848, 661),
+            "save_button": (930, 615),
+            "close_button": (883, 615),
+            "belge_tarih": (611, 462),
+            "valor_tarih": (866, 462),
+            "tutar_field": (635, 509),
+            "aciklama_field": (635, 533),
+            "yeni_belge_btn": (760, 383),
         }
 
     def execute_real_workflow(self, excel_data: dict[str, str]) -> bool:
@@ -79,6 +86,18 @@ class PrestonRPAV2:
 
     def fill_transaction_form(self, data: dict[str, str]) -> None:
         """Fill transaction form fields using Excel data."""
+        # Step 10: Click Yeni belge
+        pyautogui.click(*self.coordinates["yeni_belge_btn"])
+        time.sleep(0.5)
+
+        # Step 11a: Belge tarihi
+        pyautogui.click(*self.coordinates["belge_tarih"])
+        pyautogui.typewrite(data["tarih"])
+
+        # Step 11b: Valör tarihi
+        pyautogui.click(*self.coordinates["valor_tarih"])
+        pyautogui.typewrite(data["tarih"])
+
         # Step 12: Banka kodu
         pyautogui.click(*self.coordinates["banka_field"])
         pyautogui.typewrite(data["banka_kodu"])
@@ -87,18 +106,18 @@ class PrestonRPAV2:
         pyautogui.click(*self.coordinates["cari_field"])
         pyautogui.typewrite(data["cari_kodu"])
 
-        # Step 14: Tutar (use Tab navigation)
-        pyautogui.press("tab")
+        # Step 14: Tutar input
+        pyautogui.click(*self.coordinates["tutar_field"])
         pyautogui.typewrite(data["tutar"])
 
         # Step 15: Açıklama
-        pyautogui.press("tab")
+        pyautogui.click(*self.coordinates["aciklama_field"])
         pyautogui.typewrite(data["aciklama"])
 
     def click_save(self) -> None:
         """Trigger save action."""
-        pyautogui.hotkey("ctrl", "s")
+        pyautogui.click(*self.coordinates["save_button"])
 
     def click_close(self) -> None:
         """Close the current window."""
-        pyautogui.hotkey("alt", "f4")
+        pyautogui.click(*self.coordinates["close_button"])


### PR DESCRIPTION
## Summary
- Add default bank and client codes mapping when converting Excel data to coordinate format.
- Extend automation to click on form fields and save/close buttons using screen coordinates.

## Testing
- `PYTHONPATH=. pytest -q tests/coordinate_tests.py tests/element_detection_tests.py`


------
https://chatgpt.com/codex/tasks/task_b_689f9f81ffcc832fb68ef8a8461842a6