### PR TITLE
fix module imports for standalone execution

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -10,7 +10,13 @@ from typing import Dict, List
 
 from openpyxl import load_workbook
 
-from .logger import get_logger
+# ``excel_processor`` may be executed as a standalone module.  Attempt a
+# relative import first but fall back to an absolute import when the package
+# structure is not available.
+try:  # pragma: no cover - import behaviour
+    from .logger import get_logger
+except ImportError:  # pragma: no cover - executed when run as a script
+    from logger import get_logger
 
 logger = get_logger(__name__)
 

--- a/main.py
+++ b/main.py
@@ -12,16 +12,13 @@ from typing import List, Dict
 
 import streamlit as st
 
-if __package__ in (None, ""):
-    import sys
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
-    from preston_rpa.excel_processor import process_excel_to_coordinates
-    from preston_rpa.preston_automation_v2 import PrestonRPAV2
-    from preston_rpa.logger import get_logger
-else:
-    from .excel_processor import process_excel_to_coordinates
-    from .preston_automation_v2 import PrestonRPAV2
-    from .logger import get_logger
+# The project does not ship as an installable package, so imports need to work
+# when executed directly (e.g. ``streamlit run main.py``).  Using absolute
+# imports keeps things simple and avoids ``ModuleNotFoundError`` when the
+# package name ``preston_rpa`` is unavailable.
+from excel_processor import process_excel_to_coordinates
+from logger import get_logger
+from src.preston_automation_v2 import PrestonRPAV2
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- use absolute imports in `main.py` so it runs without `preston_rpa` package
- fall back to absolute logger import in `excel_processor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689fa6fe8b28832f91e4fb761509e00e