### PR TITLE
feat: dismiss blocking alerts in RPA workflow

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -34,9 +34,25 @@ class PrestonRPAV2:
             "yeni_belge_btn": (760, 383),
         }
 
+    def dismiss_alerts(self) -> None:
+        """Attempt to close any blocking JavaScript alerts."""
+        try:
+            pyautogui.press("esc")
+            time.sleep(0.5)
+            pyautogui.press("enter")
+            time.sleep(0.5)
+            pyautogui.press("tab")
+            pyautogui.press("enter")
+            time.sleep(0.5)
+        except Exception:
+            pass
+
     def execute_real_workflow(self, excel_data: dict[str, str]) -> bool:
         """Execute steps 4-17 using values from Excel data."""
         try:
+            # Clear potential blocking alerts
+            self.dismiss_alerts()
+
             # Step 4: Click hesap search
             pyautogui.click(*self.coordinates["hesap_search"])
             time.sleep(1)


### PR DESCRIPTION
## Summary
- add `dismiss_alerts` helper to close unexpected JavaScript pop-ups
- invoke alert handler at the start of `execute_real_workflow` to avoid blocked clicks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689faa06a384832f907a165a81525a15