### PR TITLE
Fix account selection order in Preston RPA workflow

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -55,13 +55,19 @@ class PrestonRPAV2:
 
             # Step 4: Click hesap search
             pyautogui.click(*self.coordinates["hesap_search"])
-            time.sleep(1)
+            time.sleep(2)  # Modal açılmasını bekle
 
-            # Step 5: Select account
-            pyautogui.click(*self.coordinates["account_item"])
-            time.sleep(0.5)
+            # Step 5: Select account and verify highlight
+            acc_x, acc_y = self.coordinates["account_item"]
+            before_color = pyautogui.screenshot().getpixel((acc_x, acc_y))
+            pyautogui.click(acc_x, acc_y)
+            time.sleep(1)  # Seçim işlemini bekle
+            after_color = pyautogui.screenshot().getpixel((acc_x, acc_y))
+            if after_color == before_color:
+                self.dismiss_alerts()
+                raise RuntimeError("Account selection failed")
 
-            # Step 6a: First Tamam
+            # Step 6a: First Tamam (only after a valid selection)
             pyautogui.click(*self.coordinates["tamam_button"])
             time.sleep(0.5)
 


### PR DESCRIPTION
## Summary
- wait for account modal and verify highlight before confirmation to avoid 'Lütfen bir hesap seçin' alert
- click confirmation only after a valid account selection
## Testing
- `PYTHONPATH=. pytest tests/coordinate_tests.py tests/element_detection_tests.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689fb57619c4832fafe1d372e21b339e