### PR TITLE
fix: adjust Havale alma coordinate

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -23,7 +23,7 @@ class PrestonRPAV2:
             "date_input": (197, 335),
             "yenile_btn": (48, 399),
             "yeni_btn": (223, 448),
-            "havale_alma": (848, 566),
+            "havale_alma": (695, 385),  # EFT'nin biraz üstü (Havale alma)
             "banka_field": (848, 629),
             "cari_field": (848, 661),
             "save_button": (930, 615),


### PR DESCRIPTION
## Summary
- correct `havale_alma` coordinate to point to the Havale Alma option in the workflow

## Testing
- `PYTHONPATH=. pytest tests/coordinate_tests.py tests/element_detection_tests.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a06d579284832fbcf92cd95ba42f7b