### PR TITLE
Refine account selection flow in Preston automation v2

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -18,7 +18,7 @@ class PrestonRPAV2:
             # Real workflow coordinates
             "hesap_search": (290, 305),
             "hesap_input": (1000, 497),
-            "account_item": (690, 432),
+            "account_item": (690, 432),  # mavi highlight 6293986 row
             "tamam_button": (1163, 820),
             "date_input": (197, 335),
             "yenile_btn": (48, 399),
@@ -58,16 +58,20 @@ class PrestonRPAV2:
             pyautogui.click(*self.coordinates["hesap_search"])
             time.sleep(2)
 
-            # Step 5: Type hesap number in input field
+            # Step 5: Excel'den gelen hesap no'yu input'a yaz
             pyautogui.click(*self.coordinates["hesap_input"])
-            pyautogui.typewrite("6293986")
-            time.sleep(1)
+            pyautogui.typewrite(excel_data["hesap_no"])  # Excel'den tam hesap no
+            time.sleep(1.5)  # Filter'ın çalışmasını bekle
 
-            # Step 6: Click first matching item (auto-selected)
-            pyautogui.click(*self.coordinates["account_item"])
-            time.sleep(1)
+            # Step 6: Filtered sonuçtaki tek seçeneği tıkla
+            pyautogui.click(*self.coordinates["account_item"])  # Liste itemını seçili yap
+            time.sleep(0.5)
 
-            # Step 7: Click Tamam
+            # Step 7a: İlk Tamam
+            pyautogui.click(*self.coordinates["tamam_button"])
+            time.sleep(0.5)
+
+            # Step 7b: İkinci Tamam
             pyautogui.click(*self.coordinates["tamam_button"])
             time.sleep(1)
 


### PR DESCRIPTION
## Summary
- pull hesap no from Excel and wait for filtering before selection
- add explicit account selection and double-confirmation steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a0738932b0832fa5cc4b918b9d3385