### PR TITLE
Read account number from B7 instead of B6

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -54,9 +54,9 @@ def process_excel_file(file_path: Path | str) -> List[Dict[str, object]]:
     wb = load_workbook(file_path, data_only=True)
     ws = wb.active
 
-    account_no = ws["B6"].value
+    account_no = ws["B7"].value  # Hesap numarası
     if not account_no:
-        raise ValueError("Account number (B6) not found in Excel file")
+        raise ValueError("Account number (B7) not found in Excel file")
 
     groups: Dict[str, Dict[str, object]] = defaultdict(lambda: {"toplam_tutar": 0, "islem_sayisi": 0})
 


### PR DESCRIPTION
## Summary
- Correct Excel parser to read account numbers from cell B7 rather than B6
- Adjust error message to reference new cell

## Testing
- `pytest`
- `PYTHONPATH=. pytest tests/coordinate_tests.py tests/element_detection_tests.py`


------
https://chatgpt.com/codex/tasks/task_b_68a078702e04832f96abe09618ea8920