### PR TITLE
Improve automation error reporting

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -104,8 +104,7 @@ class PrestonRPAV2:
 
             return True
         except Exception as exc:  # pragma: no cover - runtime safeguard
-            print(f"Workflow error: {exc}")
-            return False
+            raise RuntimeError(f"Workflow error: {exc}") from exc
 
     def fill_transaction_form(self, data: dict[str, str]) -> None:
         """Fill transaction form fields using Excel data."""


### PR DESCRIPTION
## Summary
- Raise RuntimeError from execute_real_workflow when the automation steps fail
- Propagate workflow failures to UI with error messages via progress queue
- Display queued errors in Streamlit interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0df563938832fa8e75e742f916ec8