### PR TITLE
Implement automatic bank and cari code selection

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -179,18 +179,18 @@ class PrestonRPAV2:
     def fill_transaction_form(self, data: dict[str, str]) -> None:
         """Fill transaction form fields using Excel data."""
 
-        # Step 13: Banka kodu - direkt input'a yaz
+        # Step 13: Banka kodu - excel'den gelen kodu yaz
         pyautogui.click(*self.coordinates["banka_input"])
         time.sleep(0.5)
         pyautogui.hotkey("ctrl", "a")  # Mevcut text'i seç
-        pyautogui.typewrite("062")  # Test banka kodu
+        pyautogui.typewrite(data["banka_kodu"])
         time.sleep(0.5)
 
-        # Step 14: Cari kodu - direkt input'a yaz
+        # Step 14: Cari kodu - excel'den gelen kodu yaz
         pyautogui.click(*self.coordinates["cari_input"])
         time.sleep(0.5)
         pyautogui.hotkey("ctrl", "a")  # Mevcut text'i seç
-        pyautogui.typewrite("120.12.001")  # Test cari kodu
+        pyautogui.typewrite(data["cari_kodu"])
         time.sleep(0.5)
 
         # Step 15: Belge tarihi

--- a/tests/test_excel_processor.py
+++ b/tests/test_excel_processor.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from excel_processor import lookup_account_codes
+
+
+def test_lookup_account_codes_success():
+    bank, cari = lookup_account_codes("233442112")
+    assert bank == "6293986"
+    assert cari == "120.12.001"
+
+
+def test_lookup_account_codes_missing():
+    with pytest.raises(ValueError):
+        lookup_account_codes("000000000")


### PR DESCRIPTION
## Summary
- add lookup helper to resolve bank and cari codes from config
- use resolved codes in coordinate conversion and form filling
- test account code lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0e24ce448832f9429e14898c9da52