### PR TITLE
feat: add random bank code fallback

### DIFF
--- a/excel_processor.py
+++ b/excel_processor.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List
+import random
 
 from openpyxl import load_workbook
 
@@ -28,6 +29,10 @@ POSH_PATTERN = re.compile(r"POSH.*\d{5,}$")
 def lookup_account_codes(account_no: str) -> tuple[str, str]:
     """Return bank and client codes for the given account number.
 
+    If the account number is unknown a random 7-digit bank code is
+    generated and logged.  This behaviour is intended solely for testing
+    scenarios where a full configuration is not yet available.
+
     Parameters
     ----------
     account_no: str
@@ -41,14 +46,17 @@ def lookup_account_codes(account_no: str) -> tuple[str, str]:
     Raises
     ------
     ValueError
-        If either code cannot be determined.
+        If the cari code cannot be determined.
     """
 
     bank_code = BANK_CODES.get(account_no)
     if not bank_code:
-        msg = f"Bank code not found for account {account_no}"
-        logger.error(msg)
-        raise ValueError(msg)
+        bank_code = f"{random.randint(1_000_000, 9_999_999)}"
+        logger.warning(
+            "Bank code not found for account %s; using random test code %s",
+            account_no,
+            bank_code,
+        )
 
     cari_code = CARI_CODES.get(account_no) or CARI_CODES.get("default")
     if not cari_code:

--- a/tests/test_excel_processor.py
+++ b/tests/test_excel_processor.py
@@ -16,6 +16,7 @@ def test_lookup_account_codes_success():
     assert cari == "120.12.001"
 
 
-def test_lookup_account_codes_missing():
-    with pytest.raises(ValueError):
-        lookup_account_codes("000000000")
+def test_lookup_account_codes_missing_generates_random_code():
+    bank, cari = lookup_account_codes("000000000")
+    assert bank.isdigit() and len(bank) == 7
+    assert cari == "120.12.001"


### PR DESCRIPTION
## Summary
- generate a random 7-digit bank code when no mapping exists
- update tests to accommodate fallback behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0e96aed14832fa445e41ece5618bf