### PR TITLE
Fix modal input coordinates

### DIFF
--- a/src/coordinates.json
+++ b/src/coordinates.json
@@ -7,12 +7,12 @@
   "yenile_btn": [48, 399],
   "yeni_btn": [223, 448],
   "havale_alma": [955, 566],
-  "banka_input": [629, 277],
-  "cari_input": [629, 309],
-  "belge_tarih_field": [629, 442],
-  "valor_tarih_field": [873, 442],
-  "tutar_input": [629, 514],
-  "aciklama_input": [629, 538],
-  "kaydet_btn": [919, 589],
-  "kapat_btn": [840, 589]
+  "banka_input": [848, 629],
+  "cari_input": [848, 661],
+  "belge_tarih_field": [650, 460],
+  "valor_tarih_field": [880, 460],
+  "tutar_input": [848, 694],
+  "aciklama_input": [650, 550],
+  "kaydet_btn": [970, 620],
+  "kapat_btn": [890, 620]
 }

--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -62,14 +62,14 @@ class PrestonRPAV2:
             "havale_alma": (955, 566),  # ✅ Gerçek "Havale alma" koordinatı
 
             # ✅ YENİ - Direkt input field'lar:
-            "banka_input": (629, 277),        # Banka input field (062 yazan yer)
-            "cari_input": (629, 309),         # Cari input field (120. yazan yer)
-            "belge_tarih_field": (629, 442),  # Belge Tarihi
-            "valor_tarih_field": (873, 442),  # Valör Tarihi
-            "tutar_input": (629, 514),        # Tutar
-            "aciklama_input": (629, 538),     # Açıklama
-            "kaydet_btn": (919, 589),         # Kaydet
-            "kapat_btn": (840, 589),          # Kapat
+            "banka_input": (848, 629),        # Banka input field (062 yazan yer)
+            "cari_input": (848, 661),         # Cari input field (120. yazan yer)
+            "belge_tarih_field": (650, 460),  # Belge Tarihi
+            "valor_tarih_field": (880, 460),  # Valör Tarihi
+            "tutar_input": (848, 694),        # Tutar
+            "aciklama_input": (650, 550),     # Açıklama
+            "kaydet_btn": (970, 620),         # Kaydet
+            "kapat_btn": (890, 620),          # Kapat
         }
 
     def calibrate_coordinate(self, key: str, path: str | Path | None = None) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- update modal field coordinates in coordinates.json
- revise default coordinates in automation script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0ef58fe50832f88294e90d04b985c