### PR TITLE
fix: correct save and close button coordinates

### DIFF
--- a/src/coordinates.json
+++ b/src/coordinates.json
@@ -13,6 +13,6 @@
   "valor_tarih_field": [880, 460],
   "tutar_input": [848, 694],
   "aciklama_input": [650, 550],
-  "kaydet_btn": [970, 620],
-  "kapat_btn": [890, 620]
+  "kaydet_btn": [1240, 794],
+  "kapat_btn": [1134, 794]
 }

--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -70,8 +70,8 @@ class PrestonRPAV2:
             "valor_tarih_field": (880, 460),  # Valör Tarihi
             "tutar_input": (848, 694),        # Tutar
             "aciklama_input": (650, 550),     # Açıklama
-            "kaydet_btn": (970, 620),         # Kaydet
-            "kapat_btn": (890, 620),          # Kapat
+            "kaydet_btn": (1240, 794),        # Kaydet
+            "kapat_btn": (1134, 794),         # Kapat
         }
 
     def calibrate_coordinate(self, key: str, path: str | Path | None = None) -> tuple[int, int]:


### PR DESCRIPTION
## Summary
- fix incorrect coordinates for Save and Close buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a0fa0675a4832fba8d50d192a1fb6d