### PR TITLE
Ensure transaction description defaults to non-empty value

### DIFF
--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -231,7 +231,10 @@ class PrestonRPAV2:
         logger.debug("Step 17: enter açıklama")
         pyautogui.click(*self.coordinates["aciklama_input"])
         time.sleep(FORM_FILL_DELAY)
-        text = data.get("aciklama", "")
+        text = data.get("aciklama", "").strip()
+        if not text:
+            text = "Havale alma işlemi"
+            logger.debug("Açıklama boş, default değer kullanılıyor")
         pyperclip.copy(text)
         pyautogui.hotkey("ctrl", "v")
         time.sleep(FORM_FILL_DELAY)


### PR DESCRIPTION
## Summary
- prevent empty description fields by inserting "Havale alma işlemi" when missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0fd05c6b4832fb74db417be7f1ce4