### PR TITLE
Fix aciklama_input coordinates

### DIFF
--- a/src/coordinates.json
+++ b/src/coordinates.json
@@ -12,7 +12,7 @@
   "belge_tarih_field": [650, 460],
   "valor_tarih_field": [880, 460],
   "tutar_input": [848, 694],
-  "aciklama_input": [650, 550],
+  "aciklama_input": [849, 726],
   "kaydet_btn": [1240, 794],
   "kapat_btn": [1134, 794]
 }

--- a/src/preston_automation_v2.py
+++ b/src/preston_automation_v2.py
@@ -69,7 +69,7 @@ class PrestonRPAV2:
             "belge_tarih_field": (650, 460),  # Belge Tarihi
             "valor_tarih_field": (880, 460),  # Valör Tarihi
             "tutar_input": (848, 694),        # Tutar
-            "aciklama_input": (650, 550),     # Açıklama
+            "aciklama_input": (849, 726),     # ✅ DOĞRU Açıklama field koordinatı
             "kaydet_btn": (1240, 794),        # Kaydet
             "kapat_btn": (1134, 794),         # Kapat
         }


### PR DESCRIPTION
## Summary
- Correct description field coordinates to (849, 726) in Preston automation and coordinate mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a0feaa30e8832fb89d46c8dd8f2e84