### PR TITLE
Document v3 automation engine dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,24 @@ Bu depo, Preston V2 web simülatörü üzerinde gerçek dünyadaki bankacılık 
 - Streamlit tabanlı web arayüzü
 - Excel dosyalarından veri çıkarma ve koordinat formatına dönüştürme
 - Tesseract ile Türkçe metin tanıma
+- Hibrit element tespitine sahip yeni v3 motoru
 - Esnek loglama ve hata yönetimi
 
 ## Gereksinimler
 - Python 3.10 veya üzeri
 - Tesseract OCR ve `tur` dil paketi
-- `pip` ile kurulabilen Python bağımlılıkları: `streamlit`, `openpyxl`, `pytesseract`, `Pillow` vb.
+- `pip` ile kurulabilen Python bağımlılıkları:
+  - `streamlit`
+  - `openpyxl`
+  - `pyautogui`, `pyperclip`
+  - `pytesseract`, `opencv-python`, `numpy`
+  - `Pillow`, `pyyaml`
 
 ## Kurulum
 ```bash
 git clone <repo>
 cd RPA_Expert2
-pip install -r requirements.txt  # dosya yoksa gerekli paketleri tek tek kurun
+pip install -r requirements.txt
 ```
 Tesseract'ı sisteminize kurduktan sonra `OCR_LANGUAGE` ayarının `tur` olduğundan emin olun.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+streamlit
+openpyxl
+pyautogui
+pyperclip
+pytesseract
+opencv-python
+numpy
+Pillow
+pyyaml


### PR DESCRIPTION
## Summary
- highlight new hybrid element detection engine in README
- add requirements.txt listing runtime dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a124fcfc58832f8ec78b1ac1182e31